### PR TITLE
Feature/deprecated annotation

### DIFF
--- a/__tests__/test-data/offline-sites/gmod-wiki/struct-custom-entity-fields.ts
+++ b/__tests__/test-data/offline-sites/gmod-wiki/struct-custom-entity-fields.ts
@@ -46,25 +46,77 @@ This can also be set from map, see <page>Sandbox Specific Mapping</page></item>
 
 </structure>`;
 
-export const apiDefinition = `---@class Custom_Entity_Fields
----@field GetEntityDriveMode function \`Serverside\`, Sandbox and Sandbox derived only.  Called by the Drive property to override the default drive type, which is \`drive_sandbox\`.
----@field OnEntityCopyTableFinish function Documented at ENTITY:OnEntityCopyTableFinish.
----@field PostEntityCopy function Documented at ENTITY:PostEntityCopy.
----@field PostEntityPaste function Documented at ENTITY:PostEntityPaste.
----@field PreEntityCopy function Documented at ENTITY:PreEntityCopy.
----@field OnDuplicated function Documented at ENTITY:OnDuplicated.
----@field PhysgunDisabled boolean \`Shared\`, Sandbox or Sandbox derived only.  If set to \`true\`, physgun will not be able to pick this entity up. This can also be set from map, see Sandbox Specific Mapping
----@field PhysgunPickup function \`Shared\`, Sandbox or Sandbox derived only.  Called from GM:PhysgunPickup, overrides \`PhysgunDisabled\`
----@field m_tblToolsAllowed table \`Shared\`, Sandbox or Sandbox derived only.  Controls which tools **and** properties can be used on this entity. Format is a list of strings where each string is the tool or property classname.  This can also be set from map, see Sandbox Specific Mapping
----@field GravGunPickupAllowed function Documented at ENTITY:GravGunPickupAllowed.
----@field GravGunPunt function Documented at ENTITY:GravGunPunt.
----@field CanProperty function Documented at ENTITY:CanProperty.
----@field CanTool function Documented at ENTITY:CanTool.
----@field CalcAbsolutePosition function Documented at ENTITY:CalcAbsolutePosition.
----@field RenderOverride function Documented at ENTITY:RenderOverride.
----@field m_RenderOrigin Vector (Clientside) Do not use.
----@field m_RenderAngles Angle (Clientside) Do not use.
-local Custom_Entity_Fields = {}\n\n`;
+export const apiDefinition =
+`---@class Custom_Entity_Fields
+local Custom_Entity_Fields = {}
+
+---\`Serverside\`, Sandbox and Sandbox derived only. Called by the Drive property to override the default drive type, which is \`drive_sandbox\`.
+---@type function
+Custom_Entity_Fields.GetEntityDriveMode = nil
+
+---Documented at ENTITY:OnEntityCopyTableFinish.
+---@type function
+Custom_Entity_Fields.OnEntityCopyTableFinish = nil
+
+---Documented at ENTITY:PostEntityCopy.
+---@type function
+Custom_Entity_Fields.PostEntityCopy = nil
+
+---Documented at ENTITY:PostEntityPaste.
+---@type function
+Custom_Entity_Fields.PostEntityPaste = nil
+
+---Documented at ENTITY:PreEntityCopy.
+---@type function
+Custom_Entity_Fields.PreEntityCopy = nil
+
+---Documented at ENTITY:OnDuplicated.
+---@type function
+Custom_Entity_Fields.OnDuplicated = nil
+
+---\`Shared\`, Sandbox or Sandbox derived only. If set to \`true\`, physgun will not be able to pick this entity up. This can also be set from map, see Sandbox Specific Mapping
+---@type boolean
+Custom_Entity_Fields.PhysgunDisabled = nil
+
+---\`Shared\`, Sandbox or Sandbox derived only. Called from GM:PhysgunPickup, overrides \`PhysgunDisabled\`
+---@type function
+Custom_Entity_Fields.PhysgunPickup = nil
+
+---\`Shared\`, Sandbox or Sandbox derived only. Controls which tools **and** properties can be used on this entity. Format is a list of strings where each string is the tool or property classname. This can also be set from map, see Sandbox Specific Mapping
+---@type table
+Custom_Entity_Fields.m_tblToolsAllowed = nil
+
+---Documented at ENTITY:GravGunPickupAllowed.
+---@type function
+Custom_Entity_Fields.GravGunPickupAllowed = nil
+
+---Documented at ENTITY:GravGunPunt.
+---@type function
+Custom_Entity_Fields.GravGunPunt = nil
+
+---Documented at ENTITY:CanProperty.
+---@type function
+Custom_Entity_Fields.CanProperty = nil
+
+---Documented at ENTITY:CanTool.
+---@type function
+Custom_Entity_Fields.CanTool = nil
+
+---Documented at ENTITY:CalcAbsolutePosition.
+---@type function
+Custom_Entity_Fields.CalcAbsolutePosition = nil
+
+---Documented at ENTITY:RenderOverride.
+---@type function
+Custom_Entity_Fields.RenderOverride = nil
+
+---(Clientside) Do not use.
+---@type Vector
+Custom_Entity_Fields.m_RenderOrigin = nil
+
+---(Clientside) Do not use.
+---@type Angle
+Custom_Entity_Fields.m_RenderAngles = nil\n\n`;
 
 export const json = {
 	name: 'Custom_Entity_Fields',

--- a/custom/class.Color.lua
+++ b/custom/class.Color.lua
@@ -3,5 +3,6 @@
 ---@field g number The green component of the color.
 ---@field b number The blue component of the color.
 ---@field a number The alpha component of the color.
----{{CLASS_FIELDS}}
 local Color = {}
+
+---{{CLASS_FIELDS}}

--- a/custom/class.ENT.lua
+++ b/custom/class.ENT.lua
@@ -1,3 +1,4 @@
 ---@class ENT : Entity
----{{CLASS_FIELDS}}
 ENT = {}
+
+---{{CLASS_FIELDS}}

--- a/custom/class.NPC.lua
+++ b/custom/class.NPC.lua
@@ -1,3 +1,4 @@
 ---@class NPC : Entity
----{{CLASS_FIELDS}}
 local NPC = {}
+
+---{{CLASS_FIELDS}}

--- a/custom/class.Player.lua
+++ b/custom/class.Player.lua
@@ -1,3 +1,4 @@
 ---@class Player : Entity
----{{CLASS_FIELDS}}
 local Player = {}
+
+---{{CLASS_FIELDS}}

--- a/custom/class.SWEP.lua
+++ b/custom/class.SWEP.lua
@@ -1,3 +1,4 @@
 ---@class SWEP : WEAPON
----{{CLASS_FIELDS}}
 SWEP = {}
+
+---{{CLASS_FIELDS}}

--- a/src/api-writer/glua-api-writer.ts
+++ b/src/api-writer/glua-api-writer.ts
@@ -112,8 +112,8 @@ export class GluaApiWriter {
           api += ` : ${parent}`;
         
         api += '\n';
-        api += classFields;
         api += `local ${className} = {}\n\n`;
+        api += classFields;
       }
 
       this.writtenClasses.add(className);

--- a/src/api-writer/glua-api-writer.ts
+++ b/src/api-writer/glua-api-writer.ts
@@ -1,5 +1,5 @@
 import { ClassFunction, Enum, Function, HookFunction, LibraryFunction, Panel, PanelFunction, Realm, Struct, WikiPage, isPanel } from '../scrapers/wiki-page-markup-scraper.js';
-import { putCommentBeforeEachLine, removeNewlines, safeFileName, toLowerCamelCase } from '../utils/string.js';
+import { escapeSingleQuotes, putCommentBeforeEachLine, removeNewlines, safeFileName, toLowerCamelCase } from '../utils/string.js';
 import {
   isClassFunction,
   isHookFunction,
@@ -69,12 +69,12 @@ export class GluaApiWriter {
     const fileSafeAddress = safeFileName(page.address, '.');
     if (this.pageOverrides.has(fileSafeAddress)) {
       let api = '';
-      
+
       if (isClassFunction(page))
-        api += this.writeClass(page.parent);
+        api += this.writeClass(page.parent, undefined, undefined, page.deprecated);
       else if (isLibraryFunction(page))
         api += this.writeLibraryGlobal(page);
-      
+
       api += this.pageOverrides.get(fileSafeAddress);
 
       return `${api}\n\n`;
@@ -94,15 +94,18 @@ export class GluaApiWriter {
       return this.writeStruct(page);
   }
 
-  private writeClass(className: string, parent?: string, classFields: string = '') {
+  private writeClass(className: string, parent?: string, classFields: string = '', deprecated?: string ) {
     let api: string = '';
 
     if (!this.writtenClasses.has(className)) {
       const classOverride = `class.${className}`;
       if (this.pageOverrides.has(classOverride)) {
         api += this.pageOverrides.get(classOverride)!.replace(/\n$/g, '') + '\n\n';
-        api = api.replace('---{{CLASS_FIELDS}}\n', classFields);
+        api = api.replace('---{{CLASS_FIELDS}}', classFields);
       } else {
+        if (deprecated)
+          api += `---@deprecated ${deprecated ?? ''}\n`
+
         api += `---@class ${className}`;
 
         if (parent)
@@ -121,7 +124,12 @@ export class GluaApiWriter {
 
   private writeLibraryGlobal(func: LibraryFunction) {
     if (!func.dontDefineParent && !this.writtenLibraryGlobals.has(func.parent)) {
-      const global = `${func.parent} = {}\n\n`;
+      let global = '';
+
+      if(func.deprecated)
+        global += `---@deprecated ${func.deprecated ?? ''}\n`;
+
+      global += `${func.parent} = {}\n\n`;
 
       this.writtenLibraryGlobals.add(func.parent);
 
@@ -132,7 +140,7 @@ export class GluaApiWriter {
   }
 
   private writeClassFunction(func: ClassFunction) {
-    let api: string = this.writeClass(func.parent);
+    let api: string = this.writeClass(func.parent, undefined, undefined, func.deprecated);
 
     api += this.writeFunctionLuaDocComment(func, func.realm);
     api += this.writeFunctionDeclaration(func, func.realm, ':');
@@ -154,7 +162,7 @@ export class GluaApiWriter {
   }
 
   private writePanel(panel: Panel) {
-    return this.writeClass(panel.name, panel.parent);
+    return this.writeClass(panel.name, panel.parent, undefined, panel.deprecated);
   }
 
   private writePanelFunction(func: PanelFunction) {
@@ -170,6 +178,9 @@ export class GluaApiWriter {
     let api: string = '';
     const isContainedInTable = _enum.items[0]?.key.includes('.') ?? false;
 
+    if (_enum.deprecated)
+      api += `---@deprecated ${_enum.deprecated ?? ''}\n`;
+
     api += `---@enum ${_enum.name}\n`;
 
     if (isContainedInTable)
@@ -180,8 +191,10 @@ export class GluaApiWriter {
         key = key.split('.')[1];
         api += `  ${key} = ${item.value}, ` + (item.description ? `--[[ ${item.description} ]]` : '') + '\n';
       } else {
-        const comment = item.description ? `${putCommentBeforeEachLine(item.description, false)}\n` : '';
-        api += `${comment}${key} = ${item.value}\n`;
+        api += item.description ? `${putCommentBeforeEachLine(item.description, false)}\n` : ''
+        if (item.deprecated)
+          api += `---@deprecated ${item.deprecated ?? ''}\n`;
+        api += `${key} = ${item.value}\n`;
       }
     };
 
@@ -196,14 +209,31 @@ export class GluaApiWriter {
     return api;
   }
 
+  private writeType(type: string, value: any) {
+    if (type === 'string')
+      return `'${escapeSingleQuotes(value)}'`;
+
+    if (type === 'Vector')
+      return `Vector${value}`;
+
+    return value;
+  }
+
   private writeStruct(struct: Struct) {
     let fields: string = '';
 
     for (const field of struct.fields) {
-      fields += `---@field ${GluaApiWriter.safeName(field.name)} ${this.transformType(field.type)} ${removeNewlines(field.description!)}\n`;
+      if (field.deprecated)
+        fields += `---@deprecated ${field.deprecated ?? ''}\n`;
+
+      fields += `---${removeNewlines(field.description).replace(/\s+/g, ' ')}\n`;
+
+      const type = this.transformType(field.type)
+      fields += `---@type ${type}\n`
+      fields += `${struct.name}.${GluaApiWriter.safeName(field.name)} = ${field.default ? this.writeType(type, field.default) : 'nil'}\n\n`;
     }
 
-    return this.writeClass(struct.name, undefined, fields);
+    return this.writeClass(struct.name, undefined, fields, struct.deprecated);
   }
 
   public writePages(pages: WikiPage[]) {
@@ -253,6 +283,9 @@ export class GluaApiWriter {
         luaDocComment += `${returns} #${this.transformType(ret.type)} - ${description}\n`;
       });
     }
+
+    if (func.deprecated)
+        luaDocComment += `---@deprecated ${func.deprecated ?? ''}\n`;
 
     return luaDocComment;
   }

--- a/src/scrapers/wiki-page-markup-scraper.ts
+++ b/src/scrapers/wiki-page-markup-scraper.ts
@@ -153,7 +153,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
               key: $el.attr('key')!,
               value: $el.attr('value')!,
               description: $el.text(),
-              deprecated,
+              deprecated: deprecated || undefined,
             };
           }).get();
 
@@ -178,7 +178,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
               type: $el.attr('type')!,
               default: $el.attr('default'),
               description: $el.text(),
-              deprecated
+              deprecated: deprecated || undefined,
             };
           }).get();
 

--- a/src/scrapers/wiki-page-markup-scraper.ts
+++ b/src/scrapers/wiki-page-markup-scraper.ts
@@ -128,7 +128,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
         const isFunction = $('function').length > 0;
         const isPanel = $('panel').length > 0;
         const mainElement = $(isEnum ? 'enum' : isStruct ? 'struct' : isPanel ? 'panel' : 'function');
-		const isDeprecated = $('deprecated').length > 0;
+        const isDeprecated = $('deprecated').length > 0;
         const address = response.url.split('/').pop()!.split('?')[0];
 
 		let deprecated: string | undefined = undefined;
@@ -144,16 +144,16 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
         if (isEnum) {
           const items = $('items item').map(function () {
             const $el = $(this);
-			const deprecated = $el.find('deprecated').map(function() {
-				const $el = $(this);
-				return $el.text().trim();
-			}).get().join(' - ');
+            const deprecated = $el.find('deprecated').map(function() {
+              const $el = $(this);
+              return $el.text().trim();
+            }).get().join(' - ');
 
             return <EnumValue>{
               key: $el.attr('key')!,
               value: $el.attr('value')!,
               description: $el.text(),
-			  deprecated,
+              deprecated,
             };
           }).get();
 
@@ -168,17 +168,17 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
         } else if (isStruct) {
           const fields = $('fields item').map(function () {
             const $el = $(this);
-			const deprecated = $el.find('deprecated').map(function() {
-				const $el = $(this);
-				return $el.text().trim();
-			}).get().join(' - ');
+            const deprecated = $el.find('deprecated').map(function() {
+              const $el = $(this);
+              return $el.text().trim();
+            }).get().join(' - ');
 
             return <StructField>{
               name: $el.attr('name')!,
               type: $el.attr('type')!,
               default: $el.attr('default'),
               description: $el.text(),
-			  deprecated
+              deprecated
             };
           }).get();
 
@@ -189,7 +189,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
             description: $('description').text(),
             realm: $('realm').text() as Realm,
             fields,
-			deprecated
+            deprecated
           };
         } else if (isPanel) {
           return <Panel>{
@@ -199,7 +199,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
             description: $('description').text(),
             realm: $('realm').text() as Realm,
             parent: $('parent').text(),
-			deprecated
+            deprecated
           };
         } else if (isFunction) {
           const isClassFunction = mainElement.attr('type') === 'classfunc';
@@ -217,7 +217,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
 
             if ($el.attr('default'))
               argument.default = $el.attr('default')!;
-            
+
             return argument;
           }).get();
 
@@ -239,7 +239,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
             realm: $('realm:first').text() as Realm,
             arguments: arguments_,
             returns,
-			deprecated
+            deprecated
           };
 
           if (isClassFunction) {
@@ -252,7 +252,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
               base.parent = '_G';
               (<LibraryFunction>base).dontDefineParent = true;
             }
-            
+
             return <LibraryFunction> {
               ...base,
               type: 'libraryfunc'

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -40,3 +40,13 @@ export function putCommentBeforeEachLine(text: string, skipLineOne: boolean = tr
 export function safeFileName(str: string, replacement: string = '_') {
   return str.replace(/[^a-z0-9_\-\. ]/gi, replacement);
 }
+
+/**
+ * Escapes all single quotes in a string
+ * 
+ * @param str The string to escape
+ * @returns The escaped string
+ */
+export function escapeSingleQuotes(str: string) {
+  return str.replace(/'/g, '\\\'');
+}


### PR DESCRIPTION
Adds the ability for the scraper to collect <deprecated> tags from the wiki and add them add `---@deprecated` tags when generating

**Changes to generating**
The normal write functions have received a simple if statement that adds the deprecated tag with reason.

The only exception is the changes in `GluaApiWriter.writeStruct` which changes the syntax from using `--@field` to instead applying a nil (or default) value directly to the class member in a local table.

*Old*
```lua
---@class SunInfo
---@field direction Vector The suns direction relative to 0,0,0
---@field obstruction number Indicates how obstructed the sun is, 1 not visible, 0 fully visible
local SunInfo = {}
```

*New*
```lua
---@class SunInfo
local SunInfo = {}

---The suns direction relative to 0,0,0
---@type Vector
SunInfo.direction = nil

---Indicates how obstructed the sun is, 1 not visible, 0 fully visible
---@type number
SunInfo.obstruction = nil
```

Making these changes to `GluaApiWriter.writeStruct` and `GluaApiWriter.writeClass` allows us to use default values where they are needed and use the `---@deprecated` tag