### PR TITLE
Optimize scraping #8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'custom/**'
   schedule:
     - cron: '0 0 1 * *'
+  workflow_dispatch:
+    inputs:
+      fullScrape:
+        description: 'Scrape the entire wiki, instead of only the changed pages'
+        required: true
+        default: false
+        type: boolean
 jobs:
   release:
     permissions: write-all
@@ -32,7 +42,14 @@ jobs:
         uses: montudor/action-zip@v1
       - name: Scrape wiki
         if: ${{ steps.wiki_confirm_no_changes.outcome == 'failure' }}
-        run: npm run scrape-wiki
+        env:
+          FULL_SCRAPE: ${{ inputs.fullScrape || false }}
+        run: |
+          if [ "$FULL_SCRAPE" = "true" ]; then
+            npm run wiki-scrape
+          else
+            npm run wiki-scrape -- --update-changed-by-tag $(git tag -l --sort=-v:refname | head -n 1)
+          fi
       - name: Format the output with StyLua
         if: ${{ steps.wiki_confirm_no_changes.outcome == 'failure' }}
         uses: JohnnyMorganz/stylua-action@v2.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "archiver": "^6.0.1",
         "cheerio": "^1.0.0-rc.12",
         "cross-env": "^7.0.3",
+        "extract-zip": "^2.0.1",
         "fetch-retry": "^5.0.6",
         "html-loader": "^4.2.0",
         "jest": "^29.7.0",
@@ -1660,6 +1661,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -2890,6 +2901,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -3135,6 +3155,41 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3161,6 +3216,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-retry": {
@@ -4969,6 +5033,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5064,6 +5134,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6251,6 +6331,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "archiver": "^6.0.1",
     "cheerio": "^1.0.0-rc.12",
     "cross-env": "^7.0.3",
+    "extract-zip": "^2.0.1",
     "fetch-retry": "^5.0.6",
     "html-loader": "^4.2.0",
     "jest": "^29.7.0",

--- a/src/scrapers/wiki-history-scraper.ts
+++ b/src/scrapers/wiki-history-scraper.ts
@@ -73,7 +73,7 @@ export class WikiHistoryPageScraper extends PageTraverseScraper<WikiHistoryPage>
           dateTime,
           user,
           change,
-          url
+          url,
         });
       }
 

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,3 +1,4 @@
+import extract from 'extract-zip';
 import archiver from 'archiver';
 import path from 'path';
 import fs from 'fs';
@@ -87,4 +88,31 @@ export async function zipFiles(outputFile: string, filePaths: string[], trimPath
 
     await archive.finalize();
   });
+}
+
+export async function unzipFiles(zipFile: string, outputDirectory: string) {
+  return new Promise<void>(async (resolve, reject) => {
+    if (!fs.existsSync(zipFile))
+      reject(new Error(`File ${zipFile} does not exist.`));
+
+    await extract(zipFile, { dir: path.resolve(outputDirectory) });
+
+    resolve();
+  });
+}
+
+export async function saveFile(file: string, stream: ReadableStream<Uint8Array>) {
+  let buffer = new Int8Array();
+  const reader = stream.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done)
+      break;
+
+    buffer = new Int8Array([...buffer, ...value]);
+  }
+
+  fs.writeFileSync(file, buffer);
 }


### PR DESCRIPTION
In #8 I stated that it would be perfectly achievable to only scrape the changed pages, instead of the entire wiki. This PR attempted to implement that, however I ran into an issue:

I seem to have been mistaken, thinking there would be a list on the gmod wiki with all changes. Using that we could scrape only updates. **However the only list I can find is https://wiki.facepunch.com/gmod/~recentchanges which shows only recent changes (last 30 days?)** and it **doesn't allow pagination** to discover more changes.

**If anyone has got any ideas around this I'm open to suggestions.**

I'll leave this PR as a draft until a solution is found. I won't actively look into a solution myself, so help is greatly appreciated. In any case this is marked low-priority, since the scraping of the entire wiki works fine (besides being a bit wasteful).