### PR TITLE
Use `dofile` to represent include functions

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,8 +9,8 @@
   "settings": {
     "Lua.runtime.version": "Lua 5.1",
     "Lua.runtime.special": {
-      "include": "require",
-      "IncludeCS": "require"
+      "include": "dofile",
+      "IncludeCS": "dofile"
     },
     "Lua.runtime.nonstandardSymbol": [
       "!",


### PR DESCRIPTION
Closes #32.

Changes `Lua.runtime.special` in the language server addon config to make the functions [`include`](https://wiki.facepunch.com/gmod/Global.include) and [`IncludeCS`](https://wiki.facepunch.com/gmod/Global.IncludeCS) be represented by [Lua 5.1's `dofile`](https://www.lua.org/manual/5.1/manual.html#pdf-dofile).

This was done because using `require` instead will yield incorrect code completion for the path, as the language server will think you're filling in a require path, which will not work at all. `dofile` will offer *much better* completion for paths, and the language server will be able to correctly identify the return type(s) from the function call.