### PR TITLE
Improve some diagnostics

### DIFF
--- a/custom/_globals.lua
+++ b/custom/_globals.lua
@@ -54,6 +54,10 @@ VERSION = nil
 VERSIONSTR = nil
 
 ---@type string
+---Contains the current networking version. Menu state only. Example: "2023.06.28"
+NETVERSIONSTR = nil
+
+---@type string
 ---The branch the game is running on. This will be "unknown" on main branch.
 BRANCH = nil
 
@@ -108,3 +112,17 @@ color_black = Color(0, 0, 0, 255)
 ---@type Color
 ---A color with only the alpha value set to 0.
 color_transparent = Color(255, 255, 255, 0)
+
+--[[
+  Table-type enums
+--]]
+
+---@type table<string, number>
+---Enumerations used by Kinect SDK bindings.
+SENSORBONE = nil
+
+---@type table<string, number>
+---Enumerations used by render.PushFilterMin and render.PushFilterMag.
+---
+---See [this](https://msdn.microsoft.com/en-us/library/windows/desktop/bb172615(v=vs.85).aspx) and [this page](https://en.wikipedia.org/wiki/Texture_filtering) for more information on texture filtering.
+TEXFILTER = nil

--- a/custom/class.CSEnt.lua
+++ b/custom/class.CSEnt.lua
@@ -1,0 +1,2 @@
+---@class CSEnt : Entity
+local CSEnt = {}

--- a/custom/class.WEAPON.lua
+++ b/custom/class.WEAPON.lua
@@ -1,2 +1,5 @@
----@class WEAPON : Entity
+---@class Weapon : Entity
+local Weapon = {}
+
+---@class WEAPON : Weapon
 local WEAPON = {}

--- a/src/scrapers/wiki-page-markup-scraper.ts
+++ b/src/scrapers/wiki-page-markup-scraper.ts
@@ -215,7 +215,7 @@ export class WikiPageMarkupScraper extends Scraper<WikiPage> {
               description: $el.text()
             };
 
-            if ($el.attr('default'))
+            if ($el.attr('default')!= undefined)
               argument.default = $el.attr('default')!;
 
             return argument;


### PR DESCRIPTION
Fixes https://github.com/luttje/glua-api-snippets/issues/36

List of changes:
* `CSEnt` inherits `Entity`
* `WEAPON` inherits `Weapon`
* `Weapon` inherits `Entity`
* `NETVERSIONSTR` global
* `SENSORBONE`, `TEXFILTER` enum globals
* string empty default values are imported correctly

Some considerations:
* Perhaps enum globals should be automatic somehow?
* `local Weapon = {}` is duplicated in the output. Not sure how to handle this, given that, at least on Windows, you cannot have the same file with different capitalization (`class.WEAPON.lua` and `class.Weapon.lua`)
