### PR TITLE
More documentation generation improvements

### DIFF
--- a/custom/_globals.lua
+++ b/custom/_globals.lua
@@ -112,17 +112,3 @@ color_black = Color(0, 0, 0, 255)
 ---@type Color
 ---A color with only the alpha value set to 0.
 color_transparent = Color(255, 255, 255, 0)
-
---[[
-  Table-type enums
---]]
-
----@type table<string, number>
----Enumerations used by Kinect SDK bindings.
-SENSORBONE = nil
-
----@type table<string, number>
----Enumerations used by render.PushFilterMin and render.PushFilterMag.
----
----See [this](https://msdn.microsoft.com/en-us/library/windows/desktop/bb172615(v=vs.85).aspx) and [this page](https://en.wikipedia.org/wiki/Texture_filtering) for more information on texture filtering.
-TEXFILTER = nil

--- a/custom/class.CSEnt.lua
+++ b/custom/class.CSEnt.lua
@@ -1,2 +1,0 @@
----@class CSEnt : Entity
-local CSEnt = {}

--- a/custom/class.NPC.lua
+++ b/custom/class.NPC.lua
@@ -1,2 +1,0 @@
----@class NPC : Entity
-local NPC = {}

--- a/custom/class.Player.lua
+++ b/custom/class.Player.lua
@@ -1,2 +1,0 @@
----@class Player : Entity
-local Player = {}

--- a/custom/class.WEAPON.lua
+++ b/custom/class.WEAPON.lua
@@ -1,5 +1,0 @@
----@class Weapon : Entity
-local Weapon = {}
-
----@class WEAPON : Weapon
-local WEAPON = {}

--- a/src/api-writer/glua-api-writer.ts
+++ b/src/api-writer/glua-api-writer.ts
@@ -184,7 +184,10 @@ export class GluaApiWriter {
     api += `---@enum ${_enum.name}\n`;
 
     if (isContainedInTable)
-      api += `local ${_enum.name} = {\n`;
+    {
+      api += _enum.description ? `${putCommentBeforeEachLine(_enum.description, false)}\n` : ''
+      api += `${_enum.name} = {\n`;
+    }
 
     const writeItem = (key: string, item: typeof _enum.items[0]) => {
       if (isContainedInTable) {

--- a/src/api-writer/glua-api-writer.ts
+++ b/src/api-writer/glua-api-writer.ts
@@ -94,7 +94,7 @@ export class GluaApiWriter {
       return this.writeStruct(page);
   }
 
-  private writeClassStart(className: string, parent?: string, deprecated?: string) {
+  private writeClassStart(className: string, parent?: string, deprecated?: string, description?: string) {
     let api: string = '';
 
     if (!this.writtenClasses.has(className)) {
@@ -102,8 +102,10 @@ export class GluaApiWriter {
       if (this.pageOverrides.has(classOverride)) {
         api += this.pageOverrides.get(classOverride)!.replace(/\n$/g, '') + '\n\n';
       } else {
+        api += description ? `${putCommentBeforeEachLine(description, false)}\n` : '';
+
         if (deprecated)
-          api += `---@deprecated ${removeNewlines(deprecated)}\n`
+          api += `---@deprecated ${removeNewlines(deprecated)}\n`;
 
         api += `---@class ${className}`;
 
@@ -160,7 +162,7 @@ export class GluaApiWriter {
   }
 
   private writePanel(panel: Panel) {
-    let api: string = this.writeClassStart(panel.name, panel.parent, panel.deprecated);
+    let api: string = this.writeClassStart(panel.name, panel.parent, panel.deprecated, panel.description);
 
     return api;
   }
@@ -185,7 +187,7 @@ export class GluaApiWriter {
 
     if (isContainedInTable)
     {
-      api += _enum.description ? `${putCommentBeforeEachLine(_enum.description, false)}\n` : ''
+      api += _enum.description ? `${putCommentBeforeEachLine(_enum.description, false)}\n` : '';
       api += `${_enum.name} = {\n`;
     }
 
@@ -194,7 +196,7 @@ export class GluaApiWriter {
         key = key.split('.')[1];
         api += `  ${key} = ${item.value}, ` + (item.description ? `--[[ ${item.description} ]]` : '') + '\n';
       } else {
-        api += item.description ? `${putCommentBeforeEachLine(item.description, false)}\n` : ''
+        api += item.description ? `${putCommentBeforeEachLine(item.description, false)}\n` : '';
         if (item.deprecated)
           api += `---@deprecated ${removeNewlines(item.deprecated)}\n`;
         api += `${key} = ${item.value}\n`;
@@ -223,7 +225,7 @@ export class GluaApiWriter {
   }
 
   private writeStruct(struct: Struct) {
-    let api: string = this.writeClassStart(struct.name, undefined, struct.deprecated);
+    let api: string = this.writeClassStart(struct.name, undefined, struct.deprecated, struct.description);
 
     for (const field of struct.fields) {
       if (field.deprecated)
@@ -232,7 +234,7 @@ export class GluaApiWriter {
       api += `---${removeNewlines(field.description).replace(/\s+/g, ' ')}\n`;
 
       const type = this.transformType(field.type)
-      api += `---@type ${type}\n`
+      api += `---@type ${type}\n`;
       api += `${struct.name}.${GluaApiWriter.safeName(field.name)} = ${field.default ? this.writeType(type, field.default) : 'nil'}\n\n`;
     }
 

--- a/src/api-writer/glua-api-writer.ts
+++ b/src/api-writer/glua-api-writer.ts
@@ -1,13 +1,16 @@
-import { ClassFunction, Enum, Function, HookFunction, LibraryFunction, Panel, PanelFunction, Realm, Struct, WikiPage, isPanel } from '../scrapers/wiki-page-markup-scraper.js';
+import { ClassFunction, Enum, Function, HookFunction, LibraryFunction, TypePage, Panel, PanelFunction, Realm, Struct, WikiPage, isPanel } from '../scrapers/wiki-page-markup-scraper.js';
 import { escapeSingleQuotes, putCommentBeforeEachLine, removeNewlines, safeFileName, toLowerCamelCase } from '../utils/string.js';
 import {
   isClassFunction,
   isHookFunction,
   isLibraryFunction,
+  isLibrary,
+  isClass,
   isPanelFunction,
   isStruct,
   isEnum,
 } from '../scrapers/wiki-page-markup-scraper.js';
+import fs from 'fs';
 
 export const RESERVERD_KEYWORDS = new Set([
   'and',
@@ -39,6 +42,8 @@ export class GluaApiWriter {
   private readonly writtenClasses: Set<string> = new Set();
   private readonly writtenLibraryGlobals: Set<string> = new Set();
   private readonly pageOverrides: Map<string, string> = new Map();
+
+  private readonly files: Map<string, WikiPage[]> = new Map();
 
   constructor() { }
 
@@ -73,7 +78,7 @@ export class GluaApiWriter {
       if (isClassFunction(page))
         api += this.writeClassStart(page.parent, undefined, page.deprecated);
       else if (isLibraryFunction(page))
-        api += this.writeLibraryGlobal(page);
+        api += this.writeLibraryGlobalFallback(page);
 
       api += this.pageOverrides.get(fileSafeAddress);
 
@@ -92,6 +97,10 @@ export class GluaApiWriter {
       return this.writeEnum(page);
     else if (isStruct(page))
       return this.writeStruct(page);
+    else if (isLibrary(page))
+      return this.writeLibraryGlobal(page);
+    else if (isClass(page))
+      return this.writeClassGlobal(page);
   }
 
   private writeClassStart(className: string, parent?: string, deprecated?: string, description?: string) {
@@ -113,7 +122,10 @@ export class GluaApiWriter {
           api += ` : ${parent}`;
 
         api += '\n';
-        api += `local ${className} = {}\n\n`;
+
+        // for PLAYER, WEAPON, etc. we want to define globals
+        if (className !== className.toUpperCase()) api += 'local ';
+        api += `${className} = {}\n\n`;
       }
 
       this.writtenClasses.add(className);
@@ -122,21 +134,42 @@ export class GluaApiWriter {
     return api;
   }
 
-  private writeLibraryGlobal(func: LibraryFunction) {
+  private writeLibraryGlobalFallback(func: LibraryFunction) {
     if (!func.dontDefineParent && !this.writtenLibraryGlobals.has(func.parent)) {
-      let global = '';
+      let api = '';
 
-      if (func.deprecated)
-        global += `---@deprecated ${removeNewlines(func.deprecated)}\n`;
-
-      global += `${func.parent} = {}\n\n`;
+      api += `---Missing description.`;
+      api += `${func.parent} = {}\n\n`;
 
       this.writtenLibraryGlobals.add(func.parent);
 
-      return global;
+      return api;
     }
 
     return '';
+  }
+
+  private writeLibraryGlobal(page: TypePage) {
+    if (!this.writtenLibraryGlobals.has(page.name)) {
+      let api = '';
+
+      api += page.description ? `${putCommentBeforeEachLine(page.description, false)}\n` : '';
+    
+      if (page.deprecated)
+        api += `---@deprecated ${removeNewlines(page.deprecated)}\n`;
+
+      api += `${page.name} = {}\n\n`;
+
+      this.writtenLibraryGlobals.add(page.name);
+
+      return api;
+    }
+
+    return '';
+  }
+  
+  private writeClassGlobal(page: TypePage) {
+    return this.writeClassStart(page.name, page.parent, page.deprecated, page.description);
   }
 
   private writeClassFunction(func: ClassFunction) {
@@ -149,7 +182,7 @@ export class GluaApiWriter {
   }
 
   private writeLibraryFunction(func: LibraryFunction) {
-    let api: string = this.writeLibraryGlobal(func);
+    let api: string = this.writeLibraryGlobalFallback(func);
 
     api += this.writeFunctionLuaDocComment(func, func.realm);
     api += this.writeFunctionDeclaration(func, func.realm);
@@ -241,14 +274,27 @@ export class GluaApiWriter {
     return api;
   }
 
-  public writePages(pages: WikiPage[]) {
-    let api: string = '';
+  public writePages(pages: WikiPage[], filePath: string) {
+    if (!this.files.has(filePath)) this.files.set(filePath, []);
+    this.files.get(filePath)!.push(...pages);
+  }
 
-    for (const page of pages) {
-      api += this.writePage(page);
-    }
+  public writeToDisk() {
+    this.files.forEach((pages: WikiPage[], filePath: string) => {
+      let api = "";
 
-    return api;
+      // First we write the "header" types
+      for (const page of pages.filter(x => isClass(x) || isLibrary(x))) {
+        api += this.writePage(page);
+      }
+      for (const page of pages.filter(x => !isClass(x) && !isLibrary(x))) {
+        api += this.writePage(page);
+      }
+
+      if (api.length > 0) {
+        fs.appendFileSync(filePath, "---@meta\n\n" + api);
+      }
+    });
   }
 
   private transformType(type: string) {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -27,7 +27,7 @@ export function putCommentBeforeEachLine(text: string, skipLineOne: boolean = tr
       return line;
 
     let space = line.length > 0 ? ' ' : '';
-    return `---${space}${line}`;
+    return `---${space}${line.trimEnd()}`;
   }).join('\n');
 }
 


### PR DESCRIPTION
My previous 2 PRs revealed an issue with library documentation where the timer library could get marked as deprecated because one of its members is deprecated. This PR addresses this, as well provides a number of other improvements:
List of changes:
* Automatically write out table enum globals and write their descriptions
* Write descriptions of panel classes and structs
* Scrape library and class definition pages, write their inheritance and descriptions, etc.
  * This required a pretty large change to how the API documentation files are written. We now keep them in memory until fetching every wiki page is done. This is necessary to ensure the library and class declarations appear first in a file. It should be fine as the total size of the output files takes up about 3MB
* Output some time statistics to wiki scraping, for comparisons between runs

If there's something needs changing to get this merged, let me know and I will see what I can do.

Fixes https://github.com/luttje/glua-api-snippets/issues/44 (Avoids the issue of class override case sensitivity thing mentioned in previous PR)